### PR TITLE
feat: add Docker and CI workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+playwright-report
+test-results
+.git
+.gitignore
+.github
+Dockerfile

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,20 +8,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.0-jammy
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Install deps
+      - name: Install dependencies
         run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
 
       - name: Run Playwright tests
         run: npx playwright test --reporter=line,html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/playwright:v1.55.0-jammy
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+RUN mkdir -p /app/playwright-report
+VOLUME ["/app/playwright-report"]
+
+CMD ["npx", "playwright", "test"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ npx playwright show-report
 
 ---
 
+## 🐳 Docker
+
+Build the Docker image:
+
+```bash
+docker build -t playwright-tests .
+```
+
+Run tests with the HTML report saved to the host:
+
+```bash
+docker run --rm -v $(pwd)/playwright-report:/app/playwright-report playwright-tests
+```
+
+The report will be available in the `playwright-report` folder.
+
+---
+
 ## 🌐 Tests Included
 
 - **UI Tests (SauceDemo)**  
@@ -79,9 +97,9 @@ npx playwright show-report
 
 This repo includes a workflow in `.github/workflows/playwright.yml`.  
 On every push or pull request to `main`:
-- Installs dependencies  
-- Installs Playwright browsers  
-- Runs all tests (UI + API)  
+- Uses the official Playwright Docker image
+- Installs dependencies
+- Runs all tests (UI + API)
 - Uploads the **HTML test report** as an artifact  
 
 You can view the status under the **Actions** tab on GitHub.


### PR DESCRIPTION
## Summary
- containerize project with official Playwright image and persist reports
- run tests in GitHub Actions using Playwright container and upload HTML report
- document Docker usage for running tests

## Testing
- `npx playwright test` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b87928a0ec83239daa36e018abad44